### PR TITLE
Add `clearModule.single()` method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,8 +40,8 @@ declare const clear: {
 	match(regex: RegExp): void;
 
 	/**
-	Clear only one single module from cache
-	@param moduleId - string identifier of module
+	Clear only a module from the cache. No parent or child modules should be affected
+	@param moduleId - What you would use with `require()`.
 	*/
 	single(moduleId: string): void;
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -40,7 +40,8 @@ declare const clear: {
 	match(regex: RegExp): void;
 
 	/**
-	Clear only a module from the cache. No parent or child modules should be affected
+	Clear one module from cache non-recursively. No parent or child modules should be affected.
+	Relevant for systems with a state that's dependant on Singelton pattern. When user would want to clear a specific module from memory without it having any "side effects" such as clearing a child module from memory as well.
 	@param moduleId - What you would use with `require()`.
 	*/
 	single(moduleId: string): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -43,6 +43,20 @@ declare const clear: {
 	Clear one module from cache non-recursively. No parent or child modules should be affected.
 	Relevant for systems with a state that's dependant on Singelton pattern. When user would want to clear a specific module from memory without it having any "side effects" such as clearing a child module from memory as well.
 	@param moduleId - What you would use with `require()`.
+
+	@example
+	In the following example, `stats` module will **not** be cleared from memory
+
+	**some-application-route.js**
+	```js
+	const stats = require('stats');
+	module.exports = () => {...}
+	```
+
+	**code manager**
+	```js
+	clearModule.single('some-application-route');
+	```
 	*/
 	single(moduleId: string): void;
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -38,6 +38,12 @@ declare const clear: {
 	@param regex - Regex to match against the module IDs.
 	*/
 	match(regex: RegExp): void;
+
+	/**
+	Clear only one single module from cache
+	@param moduleId - string identifier of module
+	*/
+	single(moduleId: string): void;
 };
 
 export = clear;

--- a/index.js
+++ b/index.js
@@ -60,4 +60,12 @@ clear.match = regex => {
 	}
 };
 
+clear.single = moduleId => {
+	if (typeof moduleId !== 'string') {
+		throw new TypeError(`Expected a \`string\`, got \`${typeof moduleId}\``);
+	}
+
+	delete require.cache[resolve(moduleId)];
+};
+
 module.exports = clear;

--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,7 @@ What you would use with `require()`.
 <summary>Example use</summary>
 "clear" function will clear only the business logic of the module, any child dependencies will remain in memory.
 
-
+This use case is relevant for systems sustaining a state that's dependant on the Singelton nature of modules. When user would want to clear a specific module from memory without it having any "side effects" such as clearing a child module from memory as well.
 
 In the following example, `stats` module will **not** be cleared from memory
 

--- a/readme.md
+++ b/readme.md
@@ -62,19 +62,11 @@ Regex to match against the module IDs.
 
 ### clearModule.single(moduleId)
 
-Clear one module from cache non-recursively
-
-#### moduleId
-
-Type: `string`
-
-What you would use with `require()`.
+Clear one module from cache non-recursively. No parent or child modules should be affected
 
 <details>
 <summary>Example use</summary>
-"clear" function will clear only the business logic of the module, any child dependencies will remain in memory.
-
-This use case is relevant for systems sustaining a state that's dependant on the Singelton nature of modules. When user would want to clear a specific module from memory without it having any "side effects" such as clearing a child module from memory as well.
+Relevant for systems with a state that's dependant on Singelton pattern. When user would want to clear a specific module from memory without it having any "side effects" such as clearing a child module from memory as well.
 
 In the following example, `stats` module will **not** be cleared from memory
 
@@ -89,6 +81,12 @@ module.exports = () => {...}
 clearModule.single('some-application-route');
 ```
 </details>
+
+#### moduleId
+
+Type: `string`
+
+What you would use with `require()`.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,15 @@ Type: `RegExp`
 
 Regex to match against the module IDs.
 
+### clearModule.single(moduleId)
+
+Clear one module from cache non-recursively
+
+#### moduleId
+
+Type: `string`
+
+What you would use with `require()`.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,26 @@ Type: `string`
 
 What you would use with `require()`.
 
+<details>
+<summary>Example use</summary>
+"clear" function will clear only the business logic of the module, any child dependencies will remain in memory.
+
+
+
+In the following example, `stats` module will **not** be cleared from memory
+
+**some-application-route.js**
+```js
+const stats = require('stats');
+module.exports = () => {...}
+```
+
+**code manager**
+```js
+clearModule.single('some-application-route');
+```
+</details>
+
 ## Related
 
 - [import-fresh](https://github.com/sindresorhus/import-fresh) - Import a module while bypassing the cache

--- a/test.js
+++ b/test.js
@@ -35,3 +35,14 @@ test('clearModule() recursively', t => {
 	clearModule(id);
 	t.is(require(id)(), 1);
 });
+
+test('clearModule.single()', t => {
+	clearModule.all();
+	const id = './fixture-with-dependency';
+	t.is(require(id)(), 1);
+	t.is(require(id)(), 2);
+	clearModule.single(id);
+	t.is(require(id)(), 3);
+	clearModule(id);
+	t.is(require(id)(), 1);
+});


### PR DESCRIPTION
Requests for the abstraction of clearing a single module in issue #11 
This function intends to accommodate to that desire

Fixes #11