### PR TITLE
Avoid exceeding maximum call stack size (circular)

### DIFF
--- a/fixture-circular-1.js
+++ b/fixture-circular-1.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const other = require('./fixture-circular-2');
+
+module.exports = other;

--- a/fixture-circular-2.js
+++ b/fixture-circular-2.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const other = require('./fixture-circular-1');
+
+module.exports = other;

--- a/index.js
+++ b/index.js
@@ -33,13 +33,15 @@ const clear = moduleId => {
 
 	// Remove all descendants from cache as well
 	if (require.cache[filePath]) {
-		for (const {id} of require.cache[filePath].children) {
+		const {children} = require.cache[filePath];
+
+		// Delete module from cache
+		delete require.cache[filePath];
+
+		for (const {id} of children) {
 			clear(id);
 		}
 	}
-
-	// Delete module from cache
-	delete require.cache[filePath];
 };
 
 clear.all = () => {

--- a/test.js
+++ b/test.js
@@ -47,12 +47,15 @@ test('clearModule.single()', t => {
 	t.is(require(id)(), 1);
 });
 
-test('Works with circular dependencies', t => {
+test('works with circular dependencies', t => {
 	const id1 = './fixture-circular-1';
 	require(id1);
+
 	let parentCalls = 0;
 	let childrenCalls = 0;
+
 	const {children, parents} = require.cache[require.resolve(id1)];
+
 	Object.defineProperty(
 		require.cache[require.resolve(id1)],
 		'children',
@@ -63,6 +66,7 @@ test('Works with circular dependencies', t => {
 			}
 		}
 	);
+
 	Object.defineProperty(
 		require.cache[require.resolve(id1)],
 		'parent',
@@ -73,6 +77,7 @@ test('Works with circular dependencies', t => {
 			}
 		}
 	);
+
 	clearModule(id1);
 	t.is(parentCalls, 1);
 	t.is(childrenCalls, 4);

--- a/test.js
+++ b/test.js
@@ -47,7 +47,7 @@ test('clearModule.single()', t => {
 	t.is(require(id)(), 1);
 });
 
-test('Avoid exceeding maximum call stack size (circular)', t => {
+test('Works with circular dependencies', t => {
 	const id1 = './fixture-circular-1';
 	require(id1);
 	let parentCalls = 0;


### PR DESCRIPTION
Delete the module from cache **before** recursion (clear child id).
Hopefully this should resolve #13 