### PR TITLE
Support for filtering modules when clearing

### DIFF
--- a/fixture-filter.js
+++ b/fixture-filter.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const x = require('parent-module');
+const fixture = require('./fixture');
+
+module.exports = () => fixture();
+module.exports.x = x;

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ declare const clear: {
 	//=> 1
 	```
 	*/
-	(moduleId: string, callback?: (moduleId: string, filePath: string) => boolean | undefined): void;
+	(moduleId: string, callback?: (fullPath: string) => boolean | undefined): void;
 
 	/**
 	Clear all modules from the cache.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,8 @@
 interface Options {
-    /**
-    Provide filter function for modules included in clearing
+	/**
+	Provide filter function for modules included in clearing
 
-    @default undefined
+	@default undefined
 	*/
 	readonly filter?: (fullPath: string) => boolean | undefined
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ declare const clear: {
 	//=> 1
 	```
 	*/
-	(moduleId: string, callback?: (filePath: string) => boolean | undefined): void;
+	(moduleId: string, callback?: (moduleId: string, filePath: string) => boolean | undefined): void;
 
 	/**
 	Clear all modules from the cache.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,10 @@
 interface Options {
 	/**
-	Optional filter function, function should return false to prevent the module from being removed from cache.
+	Optional filter function. function should return false to prevent the module from being removed from cache.
+
+  Use case: To prevent any module in node_modules from being uncached.
+
+  `clearModule('./my-module', { filter: name => !name.match(/node_modules/) })`
 
 	@default undefined
 	*/
@@ -12,7 +16,6 @@ declare const clear: {
 	Clear a module from the [cache](https://nodejs.org/api/modules.html#modules_caching).
 
 	@param moduleId - What you would use with `require()`.
-	@param options - Options
 
 	@example
 	```

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ declare const clear: {
 	//=> 1
 	```
 	*/
-	(moduleId: string): void;
+	(moduleId: string, callback?: (filePath: string) => boolean | undefined): void;
 
 	/**
 	Clear all modules from the cache.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 interface Options {
 	/**
-	Provide filter function for modules included in clearing
+	Optional filter function, function should return false to prevent the module from being removed from cache.
 
 	@default undefined
 	*/
@@ -12,7 +12,7 @@ declare const clear: {
 	Clear a module from the [cache](https://nodejs.org/api/modules.html#modules_caching).
 
 	@param moduleId - What you would use with `require()`.
-	@param options - Options, a filter function.
+	@param options - Options
 
 	@example
 	```

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,9 +2,9 @@ interface Options {
 	/**
 	Optional filter function. function should return false to prevent the module from being removed from cache.
 
-  Use case: To prevent any module in node_modules from being uncached.
+	Use case: To prevent any module in node_modules from being uncached.
 
-  `clearModule('./my-module', { filter: name => !name.match(/node_modules/) })`
+	`clearModule('./my-module', { filter: name => !name.match(/node_modules/) })`
 
 	@default undefined
 	*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,18 @@
+interface Options {
+    /**
+    Provide filter function for modules included in clearing
+
+    @default undefined
+	*/
+	readonly filter?: (fullPath: string) => boolean | undefined
+}
+
 declare const clear: {
 	/**
 	Clear a module from the [cache](https://nodejs.org/api/modules.html#modules_caching).
 
 	@param moduleId - What you would use with `require()`.
+	@param options - Options, a filter function.
 
 	@example
 	```
@@ -25,7 +35,7 @@ declare const clear: {
 	//=> 1
 	```
 	*/
-	(moduleId: string, callback?: (fullPath: string) => boolean | undefined): void;
+	(moduleId: string, options?: Options): void;
 
 	/**
 	Clear all modules from the cache.

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ interface Options {
 
 	@default undefined
 	*/
-	readonly filter?: (fullPath: string) => boolean | undefined
+	readonly filter?: (fullPath: string) => boolean | void
 }
 
 declare const clear: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ interface Options {
 
 	@default undefined
 	*/
-	readonly filter?: (fullPath: string) => boolean | void
+	readonly filter?: (fullPath: string) => boolean
 }
 
 declare const clear: {

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const clear = (moduleId, callback) => {
 		return;
 	}
 
-	if (typeof callback === 'function' && (callback(moduleId, filePath) === false)) {
+	if (typeof callback === 'function' && (callback(filePath) === false)) {
 		return;
 	}
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const resolve = moduleId => {
 	} catch (_) {}
 };
 
-const clear = (moduleId, options) => {
+const clear = (moduleId, options = {}) => {
 	if (typeof moduleId !== 'string') {
 		throw new TypeError(`Expected a \`string\`, got \`${typeof moduleId}\``);
 	}

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const resolve = moduleId => {
 	} catch (_) {}
 };
 
-const clear = (moduleId, callback) => {
+const clear = (moduleId, options) => {
 	if (typeof moduleId !== 'string') {
 		throw new TypeError(`Expected a \`string\`, got \`${typeof moduleId}\``);
 	}
@@ -20,7 +20,7 @@ const clear = (moduleId, callback) => {
 		return;
 	}
 
-	if (typeof callback === 'function' && (callback(filePath) === false)) {
+	if (typeof options === 'object' && typeof options.filter === 'function' && (options.filter(filePath) === false)) {
 		return;
 	}
 
@@ -43,7 +43,7 @@ const clear = (moduleId, callback) => {
 		delete require.cache[filePath];
 
 		for (const {id} of children) {
-			clear(id, callback);
+			clear(id, options);
 		}
 	}
 };

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const clear = (moduleId, callback) => {
 		return;
 	}
 
-	if (typeof callback === 'function' && (callback(filePath) === false)) {
+	if (typeof callback === 'function' && (callback(moduleId, filePath) === false)) {
 		return;
 	}
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const resolve = moduleId => {
 	} catch (_) {}
 };
 
-const clear = moduleId => {
+const clear = (moduleId, callback) => {
 	if (typeof moduleId !== 'string') {
 		throw new TypeError(`Expected a \`string\`, got \`${typeof moduleId}\``);
 	}
@@ -17,6 +17,10 @@ const clear = moduleId => {
 	const filePath = resolve(moduleId);
 
 	if (!filePath) {
+		return;
+	}
+
+	if (typeof callback === 'function' && (callback(filePath) === false)) {
 		return;
 	}
 
@@ -39,7 +43,7 @@ const clear = moduleId => {
 		delete require.cache[filePath];
 
 		for (const {id} of children) {
-			clear(id);
+			clear(id, callback);
 		}
 	}
 };

--- a/readme.md
+++ b/readme.md
@@ -51,9 +51,13 @@ Type: `object`
 
 Optional callback to filter with, must return false to not clear. Passes in the full path to the module. Will not process child modules of modules that are filtered out.
 
-Use case
+Use case: This allows you to prevent specific submodules from being unloaded, you may need to do this if modules are shared between always running code, and modules that are loaded/unloaded.
 
-This allows you to prevent specific submodules from being unloaded, i.e. aws-sdk, if used in main code, but you have it in modules that are being cleared out, this could adversely affect code that is not being cleared. You could also, prevent anything from node_modules from being unloaded as well, fp => !fp.match(/node_modules/). For users, this will only unload user code and not package code.
+`clearModule('./my-module', { filter: name => !name.match(/aws-sdk/) })` would prevent the aws-sdk from being cleared
+
+`clearModule('./my-module', { filter: name => !name.match(/node_modules/) })` would prevent all node_modules from being cleared
+
+Note: not the same as the match function, as the match function still clears all children of the match.
 
 ### clearModule.all()
 

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ require('./foo')();
 
 ## API
 
-### clearModule(moduleId, callback)
+### clearModule(moduleId, options)
 
 #### moduleId
 
@@ -43,13 +43,17 @@ Type: `string`
 
 What you would use with `require()`.
 
-#### callback
+#### options
 
-Type: `function`
+Type: `object`
 
-Optional callback to filter with, must return false to not clear.
-Passes in the full path to the module.
-Will not process child modules of modules that are filtered out.
+##### options.filter
+
+Optional callback to filter with, must return false to not clear. Passes in the full path to the module. Will not process child modules of modules that are filtered out.
+
+Use case
+
+This allows you to prevent specific submodules from being unloaded, i.e. aws-sdk, if used in main code, but you have it in modules that are being cleared out, this could adversely affect code that is not being cleared. You could also, prevent anything from node_modules from being unloaded as well, fp => !fp.match(/node_modules/). For users, this will only unload user code and not package code.
 
 ### clearModule.all()
 

--- a/readme.md
+++ b/readme.md
@@ -45,13 +45,9 @@ What you would use with `require()`.
 
 #### options
 
-Type: `object`
-
-Options
-
 ##### options.filter
 
-Optional filter function, function should return false to prevent the module from being removed from cache.
+Optional filter function. function should return false to prevent the module from being removed from cache.
 
 Use case: To prevent any module in node_modules from being uncached.
 

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ What you would use with `require()`.
 Type: `function`
 
 Optional callback to filter with, must return false to not clear.
-Passes in the moduleId and full path to the function.
+Passes in the full path to the module.
 Will not process child modules of modules that are filtered out.
 
 ### clearModule.all()

--- a/readme.md
+++ b/readme.md
@@ -47,17 +47,15 @@ What you would use with `require()`.
 
 Type: `object`
 
+Options
+
 ##### options.filter
 
-Optional callback to filter with, must return false to not clear. Passes in the full path to the module. Will not process child modules of modules that are filtered out.
+Optional filter function, function should return false to prevent the module from being removed from cache.
 
-Use case: This allows you to prevent specific submodules from being unloaded, you may need to do this if modules are shared between always running code, and modules that are loaded/unloaded.
+Use case: To prevent any module in node_modules from being uncached.
 
-`clearModule('./my-module', { filter: name => !name.match(/aws-sdk/) })` would prevent the aws-sdk from being cleared
-
-`clearModule('./my-module', { filter: name => !name.match(/node_modules/) })` would prevent all node_modules from being cleared
-
-Note: not the same as the match function, as the match function still clears all children of the match.
+`clearModule('./my-module', { filter: name => !name.match(/node_modules/) })`
 
 ### clearModule.all()
 

--- a/readme.md
+++ b/readme.md
@@ -35,13 +35,21 @@ require('./foo')();
 
 ## API
 
-### clearModule(moduleId)
+### clearModule(moduleId, callback)
 
 #### moduleId
 
 Type: `string`
 
 What you would use with `require()`.
+
+#### callback
+
+Type: `function`
+
+Optional callback to filter with, must return false to not clear.
+Passes in the moduleId and full path to the function.
+Will not process child modules of modules that are filtered out.
 
 ### clearModule.all()
 

--- a/test.js
+++ b/test.js
@@ -83,3 +83,14 @@ test('works with circular dependencies', t => {
 	t.is(childrenCalls, 4);
 	clearModule.all();
 });
+
+test('clear with filter', t => {
+	const id = './fixture-filter';
+	require(id);
+
+	const parentmodule = Object.keys(require.cache).find(v => v.match(/parent-module/));
+
+	t.is(typeof require.cache[parentmodule] !== 'undefined', true);
+	clearModule(id, v => !v.match(/parent-module/));
+	t.is(typeof require.cache[parentmodule] !== 'undefined', true);
+});

--- a/test.js
+++ b/test.js
@@ -91,6 +91,8 @@ test('clear with filter', t => {
 	const parentmodule = Object.keys(require.cache).find(v => v.match(/parent-module/));
 
 	t.is(typeof require.cache[parentmodule] !== 'undefined', true);
-	clearModule(id, v => !v.match(/parent-module/));
+	clearModule(id, {
+		filter: v => !v.match(/parent-module/)
+	});
 	t.is(typeof require.cache[parentmodule] !== 'undefined', true);
 });

--- a/test.js
+++ b/test.js
@@ -84,15 +84,15 @@ test('works with circular dependencies', t => {
 	clearModule.all();
 });
 
-test('clear with filter', t => {
+test('clear with filter', test_module_functions => {
 	const id = './fixture-filter';
 	require(id);
 
 	const parentmodule = Object.keys(require.cache).find(value => value.includes('parent-module'));
 
-	t.true(typeof require.cache[parentmodule] !== 'undefined');
+	test_module_functions.not(typeof require.cache[parentmodule] !== 'undefined');
 	clearModule(id, {
-		filter: v => !v.match(/parent-module/)
+		filter: absolute_path_to_cached_file => !absolute_path_to_cached_file.match(/parent-module/)
 	});
-	t.true(typeof require.cache[parentmodule] !== 'undefined');
+	test_module_functions.not(typeof require.cache[parentmodule] !== 'undefined');
 });

--- a/test.js
+++ b/test.js
@@ -88,11 +88,11 @@ test('clear with filter', t => {
 	const id = './fixture-filter';
 	require(id);
 
-	const parentmodule = Object.keys(require.cache).find(v => v.match(/parent-module/));
+	const parentmodule = Object.keys(require.cache).find(value => value.includes(/parent-module/));
 
-	t.is(typeof require.cache[parentmodule] !== 'undefined', true);
+	t.true(typeof require.cache[parentmodule] !== 'undefined');
 	clearModule(id, {
 		filter: v => !v.match(/parent-module/)
 	});
-	t.is(typeof require.cache[parentmodule] !== 'undefined', true);
+	t.true(typeof require.cache[parentmodule] !== 'undefined');
 });

--- a/test.js
+++ b/test.js
@@ -90,9 +90,9 @@ test('clear with filter', test_module_functions => {
 
 	const parentmodule = Object.keys(require.cache).find(value => value.includes('parent-module'));
 
-	test_module_functions.not(typeof require.cache[parentmodule] !== 'undefined');
+	test_module_functions.not(typeof require.cache[parentmodule] !== 'undefined', false);
 	clearModule(id, {
 		filter: absolute_path_to_cached_file => !absolute_path_to_cached_file.match(/parent-module/)
 	});
-	test_module_functions.not(typeof require.cache[parentmodule] !== 'undefined');
+	test_module_functions.not(typeof require.cache[parentmodule] !== 'undefined', false);
 });

--- a/test.js
+++ b/test.js
@@ -84,15 +84,16 @@ test('works with circular dependencies', t => {
 	clearModule.all();
 });
 
-test('clear with filter', test_module_functions => {
+test('clear with filter', t => {
+	const testModuleFunctions = t;
 	const id = './fixture-filter';
 	require(id);
 
 	const parentmodule = Object.keys(require.cache).find(value => value.includes('parent-module'));
 
-	test_module_functions.not(typeof require.cache[parentmodule] !== 'undefined', false);
+	testModuleFunctions.not(typeof require.cache[parentmodule] !== 'undefined', false);
 	clearModule(id, {
-		filter: absolute_path_to_cached_file => !absolute_path_to_cached_file.match(/parent-module/)
+		filter: absolutePathToCachedFile => !absolutePathToCachedFile.match(/parent-module/)
 	});
-	test_module_functions.not(typeof require.cache[parentmodule] !== 'undefined', false);
+	testModuleFunctions.not(typeof require.cache[parentmodule] !== 'undefined', false);
 });

--- a/test.js
+++ b/test.js
@@ -88,7 +88,7 @@ test('clear with filter', t => {
 	const id = './fixture-filter';
 	require(id);
 
-	const parentmodule = Object.keys(require.cache).find(value => value.includes(/parent-module/));
+	const parentmodule = Object.keys(require.cache).find(value => value.includes('parent-module'));
 
 	t.true(typeof require.cache[parentmodule] !== 'undefined');
 	clearModule(id, {


### PR DESCRIPTION
Added support for filtering when running clear.  This is completely backwards compatible.

I had an issue where i had 2 modules that use the same sub module, but clearing one, cleared the sub module for both of them, causing the other module to error. This would allow me to exclude specific modules out of the sub children list, and gives me absolute control over which ones to remove and which to keep