### PR TITLE
Fix for certain child modules not getting cleared

### DIFF
--- a/fixture-empty.js
+++ b/fixture-empty.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = {};

--- a/fixture-with-dependency.js
+++ b/fixture-with-dependency.js
@@ -1,5 +1,7 @@
 'use strict';
 
+// eslint-disable-next-line no-unused-vars
+const _ = require('./fixture-empty');
 const fixture = require('./fixture');
 
 module.exports = () => fixture();

--- a/index.js
+++ b/index.js
@@ -33,10 +33,7 @@ const clear = moduleId => {
 
 	// Remove all descendants from cache as well
 	if (require.cache[filePath]) {
-		const children = [];
-		for (const {id} of require.cache[filePath].children) {
-			children.push(id);
-		}
+		const children = require.cache[filePath].children.map(child => child.id);
 
 		// Delete module from cache
 		delete require.cache[filePath];

--- a/index.js
+++ b/index.js
@@ -33,12 +33,15 @@ const clear = moduleId => {
 
 	// Remove all descendants from cache as well
 	if (require.cache[filePath]) {
-		const {children} = require.cache[filePath];
+		const children = [];
+		for (const {id} of require.cache[filePath].children) {
+			children.push(id);
+		}
 
 		// Delete module from cache
 		delete require.cache[filePath];
 
-		for (const {id} of children) {
+		for (const id of children) {
 			clear(id);
 		}
 	}

--- a/test.js
+++ b/test.js
@@ -36,6 +36,16 @@ test('clearModule() recursively', t => {
 	t.is(require(id)(), 1);
 });
 
+test('clearModule() recursively, multiple imports', t => {
+	clearModule.all();
+	const id = './fixture-with-dependency';
+	t.is(require(id)(), 1);
+	t.is(require(id)(), 2);
+	t.is(require(id)(), 3);
+	clearModule(id);
+	t.is(require(id)(), 1);
+});
+
 test('clearModule.single()', t => {
 	clearModule.all();
 	const id = './fixture-with-dependency';


### PR DESCRIPTION
When clearing a module, certain child modules seem to be skipped.

This seems to be because the `require.cache[idx].parent.children` array is mutated with an `Array.splice`-call inside the next recursive call to `clear()`, skipping certain indices in the outer `for`-loop over children.

```js
while (i--) {
	if (require.cache[filePath].parent.children[i].id === filePath) {
		// seems to mutate iterator in snippet below, one level of recursion above
		require.cache[filePath].parent.children.splice(i, 1);
	}
}
```

```js
for (const {id} of children) { // certain indices of `children` do not get cleared?
	clear(id);
}
```

Making a new array fixes the issue.

Looking at the test `clearModule() recursively`, before using `clearModule`, `delete require.cache[require.resolve(id)];` is executed. I am not sure if this is part of the expected usage of the function, but the test fails if it is removed. If you swap the order of the imports in `fixture-with-dependency.js`, the test succeeds.

I chose to split the commits into three so that you may first review the failing test, and then consider how the fix should look.