### PR TITLE
fix: skip native modules (.node files) to prevent 'Unknown failure' on re-require

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,12 @@ const clear = moduleId => {
 		return;
 	}
 
+	// Skip native modules (.node files) — re-requiring them after deletion causes "Unknown failure"
+	// See: https://github.com/nodejs/node/commit/5c14d695d2c1f924cf06af6ae896027569993a5c
+	if (filePath.endsWith('.node')) {
+		return;
+	}
+
 	// Delete itself from module parent
 	if (require.cache[filePath] && require.cache[filePath].parent) {
 		let i = require.cache[filePath].parent.children.length;


### PR DESCRIPTION
## Summary
Fixes #18 — clear-module doesn't skip native modules.

## Problem
clear-module currently removes native modules ( files) from `require.cache`. Re-requiring these after deletion causes `'Error: Unknown failure'`, per the Node.js documentation linked in #18.

## Solution
Skip `.node` files early in `clear()` — just return without attempting to delete them from the cache. This matches the documented Node.js behavior.

```js
// Skip native modules (.node files) — re-requiring them after deletion causes 'Unknown failure'
// See: https://github.com/nodejs/node/commit/5c14d695d2c1f924cf06af6ae896027569993a5c
if (filePath.endsWith('.node')) {
    return;
}
```

## Testing
Existing tests pass. This change is purely additive — it only adds an early return for native modules, no behavior change for JS modules.